### PR TITLE
Add chain ID in rotation event

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,12 +453,14 @@ getService :: () => Service
 
     <p> The <code>RotationSignature</code> input parameter contains the
         signature of the data produced by concatenating the byte
-        representations of the current value's message digest, next value, and
-        current rotation count. The current rotation count is defined as the
-        sum total of successfully executed calls to both
-        <code>rotateAuthentication</code> and <code>rotateService</code> to
-        date. For example, if each function were successfully executed exactly
-        once, the current rotation count would be two.
+        representations of the current value's message digest, next value,
+        current chain identifier, and current rotation count. Including the
+        chain identifier prevents impersonating the controller on a different
+        chain. The current rotation count is defined as the sum total of
+        successfully executed calls to both <code>rotateAuthentication</code>
+        and <code>rotateService</code> to date. For example, if each function
+        were successfully executed exactly once, the current rotation count
+        would be two.
     </p>
 
     <p> <code>getAuthentication</code> returns the verification method for


### PR DESCRIPTION
Also addressed feedback on the Ed25519 key type. Instead of adding the public key in the `proof` field, I added it in the `authentication` as exemplified in the `did-core` specs.