### PR TITLE
Remove publicKeyBase58 from derived DID document

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,6 @@ digit       = %x30-39  ; 0-9
     "id": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
     "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
     "controller": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV",
     "blockchainAccountId": "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8@tezos:mainnet"
   }]
 }
@@ -514,7 +513,6 @@ getService :: () => Service
     "id": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
     "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
     "controller": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV",
     "blockchainAccountId": "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8@tezos:mainnet"
   }],
   "service": [{


### PR DESCRIPTION
Public key cannot be derived from account id.

Fixes #3. But there should probably something explaining how the `publicKeyJwk` needs to be in the proof - and how to derive the account id / DID from the public key.